### PR TITLE
:sparkles: (DebridLink) Use exact symlink path

### DIFF
--- a/server/RdtClient.Service/Services/DownloadClient.cs
+++ b/server/RdtClient.Service/Services/DownloadClient.cs
@@ -45,6 +45,11 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
                 downloadPath = AllDebridTorrentClient.GetSymlinkPath(torrent, download);
             }
 
+            if (torrent.ClientKind == Torrent.TorrentClientKind.DebridLink && Type == Data.Enums.DownloadClient.Symlink)
+            {
+                downloadPath = DebridLinkClient.GetSymlinkPath(torrent, download);
+            }
+
             if (filePath == null || downloadPath == null)
             {
                 throw new("Invalid download path");

--- a/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
@@ -62,7 +62,7 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
             var shouldSearch = true;
 
             // When resolving symlinks for AllDebrid, we know the exact file path, so we can skip the search.
-            if (clientKind == Torrent.TorrentClientKind.AllDebrid)
+            if (clientKind is Torrent.TorrentClientKind.AllDebrid or Torrent.TorrentClientKind.DebridLink)
             {
                 var potentialFilePath = Path.Combine(rcloneMountPath, path);
                 

--- a/server/RdtClient.Service/Services/TorrentClients/DebridLinkTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/DebridLinkTorrentClient.cs
@@ -6,6 +6,8 @@ using RdtClient.Data.Models.TorrentClient;
 using RdtClient.Service.Helpers;
 using DebridLinkFrNET.Models;
 using System.Web;
+using RdtClient.Data.Models.Data;
+using Torrent = RdtClient.Data.Models.Data.Torrent;
 
 namespace RdtClient.Service.Services.TorrentClients;
 
@@ -315,5 +317,21 @@ public class DebridLinkClient : ITorrentClient
         var uri = new Uri(downloadUrl);
 
         return Task.FromResult(HttpUtility.UrlDecode(uri.Segments.Last()));
+    }
+
+    public static String? GetSymlinkPath(Torrent torrent, Download download)
+    {
+        if (torrent.RdName == null || download.FileName == null)
+        {
+            return null;
+        }
+
+        // Single file torrents always have that file at `/mnt-root/Seedbox/filename.ext`
+        if (torrent.Files?.Count == 1)
+        {
+            return download.FileName;
+        }
+
+        return Path.Combine(torrent.RdName, download.FileName);
     }
 }


### PR DESCRIPTION
Adds similar logic to AD to get the exact path for the symlink source.
Without this, single file torrents will fail (but if I understand correctly, multi-file torrents will be just fine).

I figured given this is a patch, it would be best as a PR to your PR branch, but we can move this discussion to the [PR](https://github.com/rogerfar/rdt-client/pull/680) if you'd rather.